### PR TITLE
Add support for get/set of raw (binary) values

### DIFF
--- a/memcache.py
+++ b/memcache.py
@@ -743,6 +743,8 @@ class Client(local):
         # (most blatantly, bool --> int)
         if type(val) == str:
             val = val.encode('utf-8')
+        elif type(val) == bytes:
+            pass # we already have a valid bytestream
         elif type(val) == int:
             flags |= Client._FLAG_INTEGER
             val = str(val).encode('ascii')

--- a/memcache.py
+++ b/memcache.py
@@ -891,12 +891,14 @@ class Client(local):
         '''
         return self._get('get', key, as_text)
 
-    def gets(self, key):
+    def gets(self, key, as_text=True):
         '''Retrieves a key from the memcache. Used in conjunction with 'cas'.
+
+        @param as_text: If False, the value is a binary blob and will be returned as a bytes
 
         @return: The value or None.
         '''
-        return self._get('gets', key)
+        return self._get('gets', key, as_text)
 
     def get_multi(self, keys, key_prefix='', as_text=True):
         '''

--- a/memcache.py
+++ b/memcache.py
@@ -834,7 +834,7 @@ class Client(local):
                 server.mark_dead(msg)
             return 0
 
-    def _get(self, cmd, key):
+    def _get(self, cmd, key, as_text=True):
         if self.do_check_key:
             self.check_key(key)
         server, key = self._get_server(key)
@@ -860,7 +860,7 @@ class Client(local):
                 if not rkey:
                     return None
                 try:
-                    value = self._recv_value(server, flags, rlen)
+                    value = self._recv_value(server, flags, rlen, as_text)
                 finally:
                     server.expect(b"END", raise_exception=True)
             except (_Error, socket.error) as msg:
@@ -882,12 +882,14 @@ class Client(local):
                 server.mark_dead(msg)
             return None
 
-    def get(self, key):
+    def get(self, key, as_text=True):
         '''Retrieves a key from the memcache.
+    
+        @param as_text: If False, the value is a binary blob and will be returned as a bytes
 
         @return: The value or None.
         '''
-        return self._get('get', key)
+        return self._get('get', key, as_text)
 
     def gets(self, key):
         '''Retrieves a key from the memcache. Used in conjunction with 'cas'.
@@ -896,7 +898,7 @@ class Client(local):
         '''
         return self._get('gets', key)
 
-    def get_multi(self, keys, key_prefix=''):
+    def get_multi(self, keys, key_prefix='', as_text=True):
         '''
         Retrieves multiple keys from the memcache doing just one query.
 
@@ -930,6 +932,7 @@ class Client(local):
         @param keys: An array of keys.
         @param key_prefix: A string to prefix each key when we communicate with memcache.
             Facilitates pseudo-namespaces within memcache. Returned dictionary keys will not have this prefix.
+        @param as_text: If False, values are binary blobs and will be returned as bytes
         @return:  A dictionary of key/value pairs that were available. If key_prefix was provided, the keys in the retured dictionary will not have it present.
 
         '''
@@ -963,7 +966,7 @@ class Client(local):
                     if rkey is not None:
                         if isinstance(rkey,bytes):
                             rkey = rkey.decode()
-                        val = self._recv_value(server, flags, rlen)
+                        val = self._recv_value(server, flags, rlen, as_text)
                         retvals[prefixed_to_orig_key[rkey]] = val   # un-prefix returned key.
                     line = server.readline()
             except (_Error, socket.error) as msg:
@@ -993,7 +996,7 @@ class Client(local):
         else:
             return (None, None, None)
 
-    def _recv_value(self, server, flags, rlen):
+    def _recv_value(self, server, flags, rlen, as_text=True):
         rlen += 2 # include \r\n
         buf = server.recv(rlen)
         if len(buf) != rlen:
@@ -1007,7 +1010,10 @@ class Client(local):
 
         if  flags == 0 or flags == Client._FLAG_COMPRESSED:
             # Either a bare string or a compressed string now decompressed...
-            val = buf.decode('utf-8')
+            if as_text:
+                val = buf.decode('utf-8')
+            else:
+                val = buf # directly return the bytes
         elif flags & Client._FLAG_INTEGER:
             val = int(buf)
         elif flags & Client._FLAG_LONG:


### PR DESCRIPTION
Currently, python3-memcached makes the assumption that values are always textual ie. they can always be encoded to and decoded from utf8.

This PR adds support for storing random binary blobs.

It fixes two things :
- Allow set operations with a bytes value : it it directly passed to memcached without pickling it first
- Add a new param as_text (with default value to True to ensure backward compatibility) to all get operations. If False, python3-memcached won't try to decode the value as utf8 and directly pass it back as a bytes